### PR TITLE
fix: sanitize file names and YAML titles for Windows compatibility

### DIFF
--- a/src/usecases/UpdateFeeds.ts
+++ b/src/usecases/UpdateFeeds.ts
@@ -211,10 +211,10 @@ export class UpdateFeeds {
 	 */
 	private async saveRssItem(rssItem: RssItem, folderPath: string): Promise<void> {
 		let fileName = this.settings.fileNameTemplate
-			.replace(/{{title}}/g, rssItem.title)
+			.replace(/{{title}}/g, rssItem.title.trim())
 			.replace(/{{published}}/g, this.formatDateTime(new Date(rssItem.pubDate)));
 
-		fileName = fileName.replace(/[\\/:*?"<>|]/g, '-');
+		fileName = fileName.replace(/[\\/:*?"<>|]/g, '-').trim();
 		fileName = normalizePath(`${folderPath}/${fileName}.md`);
 
 		const existingFile = this.vault.getAbstractFileByPath(fileName);

--- a/src/utils/yamlFormatter.ts
+++ b/src/utils/yamlFormatter.ts
@@ -1,4 +1,5 @@
 const YAML_SPECIAL_CHARS = /[[\]{}:>|*&!%@,]/;
+const YAML_DANGEROUS_START = /^[["']/;
 
 /**
  * YAML値をエスケープ
@@ -9,7 +10,8 @@ export function escapeYamlValue(value: string): string {
 	// 改行文字を空白に置き換える
 	const valueWithoutNewlines = value.replace(/\r?\n/g, ' ').trim();
 
-	if (YAML_SPECIAL_CHARS.test(valueWithoutNewlines)) {
+	// 特殊文字を含む OR 危険な先頭文字（[, ", '）の場合はクォートで囲む
+	if (YAML_SPECIAL_CHARS.test(valueWithoutNewlines) || YAML_DANGEROUS_START.test(valueWithoutNewlines)) {
 		const escapedValue = valueWithoutNewlines.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 		return `"${escapedValue}"`;
 	}


### PR DESCRIPTION
## Summary
- ファイル名の前後スペースを`trim()`で除去（OneDrive同期問題を解決）
- `[`, `"`, `'`で始まるタイトルをYAMLで適切にクォート処理

## Test plan
- [ ] 前後にスペースがあるタイトルの記事を取得し、ファイル名にスペースがないことを確認
- [ ] `[Breaking]`のようなタイトルの記事を取得し、Frontmatterが正しくパースされることを確認

Closes #31
