### PR TITLE
feat: support date format filter pipe syntax in templates

### DIFF
--- a/src/services/ArticleRenderer.ts
+++ b/src/services/ArticleRenderer.ts
@@ -33,6 +33,8 @@ export class ArticleRenderer {
 			author: escapedAuthor,
 			publishedTime: formatDateTime(pubDate),
 			savedTime: formatDateTime(savedDate),
+			publishedDate: pubDate,
+			savedDate: savedDate,
 			image: rssItem.imageUrl,
 			description: escapedDescription,
 			descriptionShort: escapedDescriptionShort,

--- a/src/services/FileNameGenerator.ts
+++ b/src/services/FileNameGenerator.ts
@@ -13,9 +13,11 @@ export class FileNameGenerator {
 	 * @returns サニタイズされたファイル名（拡張子なし）
 	 */
 	generate(template: string, title: string, pubDate: string): string {
+		const date = new Date(pubDate);
 		let fileName = template
 			.replace(/{{title}}/g, title.trim())
-			.replace(/{{published}}/g, formatDateTime(new Date(pubDate)));
+			.replace(/{{published\s*\|\s*date\(['"](.*?)['"]\)}}/g, (_, fmt) => formatDateTime(date, fmt))
+			.replace(/{{published}}/g, formatDateTime(date));
 
 		fileName = fileName.replace(/[\\/:*?"<>|]/g, '-').trim();
 		return fileName;

--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -1,9 +1,10 @@
 /**
  * 日時をフォーマットされた文字列に変換
  * @param date Dateオブジェクト
- * @returns YYYY-MM-DD HH:mm:ss 形式の文字列
+ * @param format フォーマット文字列（省略時: 'YYYY-MM-DD HH:mm:ss'）
+ * @returns フォーマットされた文字列
  */
-export function formatDateTime(date: Date): string {
+export function formatDateTime(date: Date, format = 'YYYY-MM-DD HH:mm:ss'): string {
 	const year = date.getFullYear();
 	const month = String(date.getMonth() + 1).padStart(2, '0');
 	const day = String(date.getDate()).padStart(2, '0');
@@ -11,5 +12,11 @@ export function formatDateTime(date: Date): string {
 	const minutes = String(date.getMinutes()).padStart(2, '0');
 	const seconds = String(date.getSeconds()).padStart(2, '0');
 
-	return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+	return format
+		.replace(/YYYY/g, String(year))
+		.replace(/MM/g, month)
+		.replace(/DD/g, day)
+		.replace(/HH/g, hours)
+		.replace(/mm/g, minutes)
+		.replace(/ss/g, seconds);
 }

--- a/src/utils/templateEngine.ts
+++ b/src/utils/templateEngine.ts
@@ -1,5 +1,6 @@
 import { RssItem } from '../types';
 import { escapeYamlValue } from './yamlFormatter';
+import { formatDateTime } from './dateFormatter';
 
 /**
  * テンプレートの前処理
@@ -27,6 +28,8 @@ export interface TemplateData {
 	author: string;
 	publishedTime: string;
 	savedTime: string;
+	publishedDate: Date;
+	savedDate: Date;
 	image: string;
 	description: string;
 	descriptionShort: string;
@@ -45,7 +48,9 @@ export function renderTemplate(template: string, data: TemplateData): string {
 		.replace(/{{title}}/g, data.title)
 		.replace(/{{link}}/g, data.link)
 		.replace(/{{author}}/g, data.author)
+		.replace(/{{publishedTime\s*\|\s*date\(['"](.*?)['"]\)}}/g, (_, fmt) => formatDateTime(data.publishedDate, fmt))
 		.replace(/{{publishedTime}}/g, data.publishedTime)
+		.replace(/{{savedTime\s*\|\s*date\(['"](.*?)['"]\)}}/g, (_, fmt) => formatDateTime(data.savedDate, fmt))
 		.replace(/{{savedTime}}/g, data.savedTime)
 		.replace(/{{image}}/g, data.image)
 		.replace(/{{description}}/g, data.description)

--- a/tests/services/ArticleRenderer.test.ts
+++ b/tests/services/ArticleRenderer.test.ts
@@ -30,6 +30,8 @@ describe('ArticleRenderer', () => {
 			expect(data.tags).toBe('#tech #news');
 			expect(data.publishedTime).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
 			expect(data.savedTime).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+			expect(data.publishedDate).toBeInstanceOf(Date);
+			expect(data.savedDate).toBeInstanceOf(Date);
 		});
 
 		it('should escape YAML special characters in title', () => {

--- a/tests/services/FileNameGenerator.test.ts
+++ b/tests/services/FileNameGenerator.test.ts
@@ -40,4 +40,30 @@ describe('FileNameGenerator', () => {
 		const result = generator.generate('  {{title}}  ', 'Title', '2025-01-01T00:00:00Z');
 		expect(result).toBe('Title');
 	});
+
+	it('should support date filter pipe syntax with single quotes', () => {
+		const result = generator.generate("{{published | date('YYYY-MM-DD')}} - {{title}}", 'My Article', '2025-01-15T09:00:00Z');
+		const date = new Date('2025-01-15T09:00:00Z');
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const day = String(date.getDate()).padStart(2, '0');
+		expect(result).toBe(`${year}-${month}-${day} - My Article`);
+	});
+
+	it('should support date filter pipe syntax with double quotes', () => {
+		const result = generator.generate('{{published | date("YYYY-MM-DD")}} - {{title}}', 'My Article', '2025-01-15T09:00:00Z');
+		const date = new Date('2025-01-15T09:00:00Z');
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const day = String(date.getDate()).padStart(2, '0');
+		expect(result).toBe(`${year}-${month}-${day} - My Article`);
+	});
+
+	it('should support custom date format', () => {
+		const result = generator.generate("{{published | date('MM-DD')}}", 'Title', '2025-06-20T12:00:00Z');
+		const date = new Date('2025-06-20T12:00:00Z');
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const day = String(date.getDate()).padStart(2, '0');
+		expect(result).toBe(`${month}-${day}`);
+	});
 });

--- a/tests/utils/dateFormatter.test.ts
+++ b/tests/utils/dateFormatter.test.ts
@@ -21,4 +21,19 @@ describe('formatDateTime', () => {
 		const date = new Date(2025, 5, 15, 23, 59, 59); // 2025-06-15 23:59:59
 		expect(formatDateTime(date)).toBe('2025-06-15 23:59:59');
 	});
+
+	it('should support custom format YYYY-MM-DD', () => {
+		const date = new Date(2025, 0, 15, 9, 5, 3);
+		expect(formatDateTime(date, 'YYYY-MM-DD')).toBe('2025-01-15');
+	});
+
+	it('should support custom format YYYY/MM/DD HH:mm', () => {
+		const date = new Date(2025, 5, 20, 14, 30, 0);
+		expect(formatDateTime(date, 'YYYY/MM/DD HH:mm')).toBe('2025/06/20 14:30');
+	});
+
+	it('should support custom format MM-DD', () => {
+		const date = new Date(2025, 2, 5, 0, 0, 0);
+		expect(formatDateTime(date, 'MM-DD')).toBe('03-05');
+	});
 });

--- a/tests/utils/templateEngine.test.ts
+++ b/tests/utils/templateEngine.test.ts
@@ -48,6 +48,8 @@ describe('renderTemplate', () => {
 			author: 'John',
 			publishedTime: '2025-01-01 00:00:00',
 			savedTime: '2025-01-01 12:00:00',
+			publishedDate: new Date('2025-01-01T00:00:00Z'),
+			savedDate: new Date('2025-01-01T12:00:00Z'),
 			image: '',
 			description: 'A description',
 			descriptionShort: 'A des...',
@@ -69,6 +71,8 @@ describe('renderTemplate', () => {
 			author: '',
 			publishedTime: '',
 			savedTime: '',
+			publishedDate: new Date(),
+			savedDate: new Date(),
 			image: '',
 			description: '',
 			descriptionShort: '',
@@ -76,5 +80,45 @@ describe('renderTemplate', () => {
 			content: '',
 		});
 		expect(result).toBe('Dup - Dup');
+	});
+
+	it('should support date filter pipe syntax for publishedTime', () => {
+		const template = "date: {{publishedTime | date('YYYY-MM-DD')}}";
+		const pubDate = new Date(2025, 0, 15, 9, 30, 0);
+		const result = renderTemplate(template, {
+			title: '',
+			link: '',
+			author: '',
+			publishedTime: '2025-01-15 09:30:00',
+			savedTime: '',
+			publishedDate: pubDate,
+			savedDate: new Date(),
+			image: '',
+			description: '',
+			descriptionShort: '',
+			tags: '',
+			content: '',
+		});
+		expect(result).toBe('date: 2025-01-15');
+	});
+
+	it('should support date filter pipe syntax for savedTime', () => {
+		const template = "saved: {{savedTime | date('YYYY/MM/DD HH:mm')}}";
+		const savedDate = new Date(2025, 5, 20, 14, 30, 0);
+		const result = renderTemplate(template, {
+			title: '',
+			link: '',
+			author: '',
+			publishedTime: '',
+			savedTime: '2025-06-20 14:30:00',
+			publishedDate: new Date(),
+			savedDate: savedDate,
+			image: '',
+			description: '',
+			descriptionShort: '',
+			tags: '',
+			content: '',
+		});
+		expect(result).toBe('saved: 2025/06/20 14:30');
 	});
 });


### PR DESCRIPTION
## Summary
- Add date format filter pipe syntax to file name and content templates
- Templates now support `{{published | date('YYYY-MM-DD')}}` and similar patterns for publishedTime/savedTime

## Changes
- dateFormatter: accept optional custom format string (default unchanged: YYYY-MM-DD HH:mm:ss)
- FileNameGenerator: parse `{{published | date('FORMAT')}}` pipe syntax
- templateEngine: parse `{{publishedTime | date('FORMAT')}}` and `{{savedTime | date('FORMAT')}}` pipe syntax
- ArticleRenderer: pass raw Date objects (publishedDate, savedDate) to TemplateData
- Add tests for custom date formats, pipe syntax in file names and content templates

Closes #36