### PR TITLE
feat: add "One file per feed" mode

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
       "eslint:recommended",
       "plugin:@typescript-eslint/eslint-recommended",
       "plugin:@typescript-eslint/recommended"
-    ], 
+    ],
     "parserOptions": {
         "sourceType": "module"
     },
@@ -19,5 +19,5 @@
       "@typescript-eslint/ban-ts-comment": "off",
       "no-prototype-builtins": "off",
       "@typescript-eslint/no-empty-function": "off"
-    } 
+    }
   }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # vscode
-.vscode 
+.qodo
 
 # Intellij
 *.iml
@@ -7,6 +7,7 @@
 
 # npm
 node_modules
+package-lock.json
 
 # Don't include the compiled main.js file in the repo.
 # They should be uploaded to GitHub releases instead.

--- a/.vscode/Obsidian-Local-RSS.code-workspace
+++ b/.vscode/Obsidian-Local-RSS.code-workspace
@@ -1,0 +1,21 @@
+{
+	"folders": [
+		{
+			"name": "Local RSS  -  root",
+			"path": ".."
+		}
+	],
+
+	"settings": {
+		"explorer.fileNesting.expand": false,
+		"explorer.fileNesting.patterns": {
+			"README.md": "README*.md, AUTHORS, Authors, BACKERS*, Backers*, CHANGELOG*, CITATION*, CODEOWNERS, CODE_OF_CONDUCT*, CONTRIBUTING*, CONTRIBUTORS, COPYING*, CREDITS, Changelog*, Citation*, Code_Of_Conduct*, Codeowners, Contributing*, Contributors, Copying*, Credits, GOVERNANCE.MD, Governance.md, HISTORY.MD, History.md, LICENSE*, License*, MAINTAINERS, Maintainers, README-*, README_*, RELEASE_NOTES*, ROADMAP.MD, Readme-*, Readme_*, Release_Notes*, Roadmap.md, SECURITY.MD, SPONSORS*, Security.md, Sponsors*, authors, backers*, changelog*, citation*, code_of_conduct*, codeowners, contributing*, contributors, copying*, credits, governance.md, history.md, license*, maintainers, readme-*, readme_*, release_notes*, roadmap.md, security.md, sponsors*",
+			".editorconfig": ".prettierrc, cspell.json, esbuild.config.mjs, eslint.config.m*s, tsconfig.json",
+		},
+
+		"files.exclude": {
+			"**/.qodo": true,
+			"**/node_modules": true,
+		},
+	}
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+	"recommendations": [
+		"batyan-soft.fast-tasks",
+		"editorconfig.editorconfig",
+		"usernamehw.errorlens",
+		"shardulm94.trailing-spaces"
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,35 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "npm run build",
+			"type": "shell",
+			"command": "npm",
+			"args": [
+				"run",
+				"build"
+			],
+			"problemMatcher": []
+		},
+		{
+			"label": "npm run dev",
+			"type": "shell",
+			"command": "npm",
+			"args": [
+				"run",
+				"dev"
+			],
+			"problemMatcher": []
+		},
+		{
+			"label": "vitest run",
+			"type": "shell",
+			"command": "npm",
+			"args": [
+				"run",
+				"dev"
+			],
+			"problemMatcher": []
+		}
+	]
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 	"license": "MIT",
 	"devDependencies": {
 		"@types/jsdom": "^27.0.0",
-		"@types/node": "^16.11.6",
+		"@types/node": "^20.19.39",
 		"@types/sanitize-html": "^2.16.0",
 		"@types/turndown": "^5.0.5",
 		"@types/xml2js": "^0.4.11",

--- a/src/adapters/i18n/locales/en.ts
+++ b/src/adapters/i18n/locales/en.ts
@@ -2,7 +2,7 @@ export default {
 	// Commands
 	updateRssFeeds: 'Update RSS feeds',
 	addRssFeed: 'Add RSS feed',
-	
+
 	// Notices
 	updatingRssFeeds: 'Updating RSS feeds...',
 	failedToFetchFeed: 'Failed to fetch feed: %0',
@@ -13,10 +13,12 @@ export default {
 	feedNameRequired: 'Feed name is required',
 	feedUrlRequired: 'Feed URL is required',
 	addedFeed: 'Added feed: %0',
-	
+
 	// Settings
 	rssFolder: 'RSS folder',
 	rssFolderDesc: 'Folder where RSS articles will be saved',
+	singleFilePerFeed: 'One file per feed',
+	singleFilePerFeedDesc: 'Instead of creating one file per article, create a single Markdown file per feed with all articles as sections inside it. New articles are added to the top.',
 	fileNameTemplate: 'File name template',
 	fileNameTemplateDesc: 'Template for article file names. Variables {{title}} and {{published}} available',
 	contentTemplate: 'Content template',
@@ -52,14 +54,14 @@ export default {
 	addNewFeedDesc: 'Add a new RSS feed to download',
 	updateFeedsNow: 'Update feeds now',
 	updateFeedsNowDesc: 'Manually update all enabled RSS feeds',
-	
+
 	// Modal
 	feedName: 'Feed name',
 	feedUrl: 'Feed URL',
 	customFolderName: 'Custom folder name (optional)',
 	customFolderNameDesc: 'Subfolder name within RSS folder',
 	customFolderPlaceholder: 'Leave empty to use feed name',
-	
+
 	// Buttons
 	addFeed: 'Add feed',
 	editFeed: 'Edit feed',
@@ -69,14 +71,14 @@ export default {
 	updateNow: 'Update now',
 	savedFeed: 'Saved feed: %0',
 	errorSavingFeed: 'Failed to save feed',
-	
+
 	// Settings header
 	rssFeedDownloaderSettings: 'RSS feed downloader settings',
-	
+
 	// Time units
 	days: 'Days',
 	minutes: 'Minutes',
-	
+
 	// Date options
 	publishedDate: 'Published date',
 	savedDate: 'Saved date',

--- a/src/adapters/i18n/locales/ja.ts
+++ b/src/adapters/i18n/locales/ja.ts
@@ -4,7 +4,7 @@ const ja: Partial<typeof en> = {
 	// Commands
 	updateRssFeeds: 'RSS フィードを更新',
 	addRssFeed: 'RSS フィードを追加',
-	
+
 	// Notices
 	updatingRssFeeds: 'RSSフィードを更新中...',
 	failedToFetchFeed: 'フィードの取得に失敗しました: %0',
@@ -15,7 +15,7 @@ const ja: Partial<typeof en> = {
 	feedNameRequired: 'フィード名は必須です',
 	feedUrlRequired: 'フィードURLは必須です',
 	addedFeed: 'フィードを追加しました: %0',
-	
+
 	// Settings
 	rssFolder: 'RSSフォルダ',
 	rssFolderDesc: 'RSSの記事が保存されるフォルダ',
@@ -54,14 +54,14 @@ const ja: Partial<typeof en> = {
 	addNewFeedDesc: 'ダウンロードする新しいRSSフィードを追加',
 	updateFeedsNow: '今すぐフィードを更新',
 	updateFeedsNowDesc: '有効なすべてのRSSフィードを手動で更新',
-	
+
 	// Modal
 	feedName: 'フィード名',
 	feedUrl: 'フィードURL',
 	customFolderName: 'カスタムフォルダ名（オプション）',
 	customFolderNameDesc: 'RSSフォルダ内のサブフォルダ名',
 	customFolderPlaceholder: 'フィード名を使用する場合は空のままにしてください',
-	
+
 	// Buttons
 	addFeed: 'フィードを追加',
 	editFeed: 'フィードを編集',
@@ -71,14 +71,14 @@ const ja: Partial<typeof en> = {
 	updateNow: '今すぐ更新',
 	savedFeed: 'フィードを保存しました: %0',
 	errorSavingFeed: 'フィードの保存に失敗しました',
-	
+
 	// Settings header
 	rssFeedDownloaderSettings: 'RSSフィードダウンローダー設定',
-	
+
 	// Time units
 	days: '日',
 	minutes: '分',
-	
+
 	// Date options
 	publishedDate: '公開日',
 	savedDate: '保存日',

--- a/src/adapters/i18n/locales/pt.ts
+++ b/src/adapters/i18n/locales/pt.ts
@@ -1,0 +1,98 @@
+export default {
+	// Commands
+	updateRssFeeds: 'Atualizar feeds RSS',
+	addRssFeed: 'Adicionar feed RSS',
+
+	// Notices
+	updatingRssFeeds: 'Atualizando feeds RSS...',
+	failedToFetchFeed: 'Falha ao buscar feed: %0',
+	unsupportedFeedFormat: 'Formato de feed não suportado: %0',
+	updatedFeed: 'Feed atualizado: %0',
+	errorUpdatingFeed: 'Erro ao atualizar feed: %0',
+	rssFeedUpdateCompleted: 'Atualização dos feeds RSS concluída',
+	feedNameRequired: 'O nome do feed é obrigatório',
+	feedUrlRequired: 'A URL do feed é obrigatória',
+	addedFeed: 'Feed adicionado: %0',
+
+	// Settings
+	rssFolder: 'Pasta RSS',
+	rssFolderDesc: 'Pasta onde os artigos RSS serão salvos',
+	singleFilePerFeed: 'Um arquivo por feed',
+	singleFilePerFeedDesc: 'Em vez de criar um arquivo por artigo, cria um único arquivo Markdown por feed com todos os artigos como seções. Novos artigos são adicionados ao topo.',
+	fileNameTemplate: 'Template do nome do arquivo',
+	fileNameTemplateDesc: 'Template para o nome dos arquivos de artigos. Variáveis {{title}} e {{published}} disponíveis',
+	contentTemplate: 'Template de conteúdo',
+	contentTemplateDesc: 'Template para o conteúdo dos artigos com front matter',
+	availableVariables: 'Variáveis disponíveis',
+	varTitle: 'Título do artigo',
+	varLink: 'URL do artigo original',
+	varAuthor: 'Nome do autor do artigo',
+	varPublishedTime: 'Data e hora de publicação',
+	varSavedTime: 'Data e hora em que foi salvo',
+	varImage: 'URL da imagem do artigo',
+	varDescription: 'Descrição completa do artigo',
+	varDescriptionShort: 'Descrição (resumida)',
+	varContent: 'Conteúdo completo do artigo',
+	varTags: 'Categorias como hashtags',
+	updateInterval: 'Intervalo de atualização',
+	updateIntervalDesc: 'Com que frequência verificar os feeds (em minutos, 0 para desativar)',
+	includeImages: 'Incluir imagens',
+	includeImagesDesc: 'Incluir URLs de imagens dos artigos do feed',
+	fetchImageFromLink: 'Buscar imagem pelo link',
+	fetchImageFromLinkDesc: 'Se o feed RSS não tiver imagem, busca a imagem OGP pelo link do artigo (pode demorar mais)',
+	imageWidth: 'Largura das imagens',
+	imageWidthDesc: 'Largura das imagens no conteúdo (ex: 50%, 300px)',
+	autoDeleteOldArticles: 'Excluir artigos antigos automaticamente',
+	autoDeleteOldArticlesDesc: 'Exclui artigos automaticamente após um determinado período',
+	periodBeforeDeletion: 'Período antes da exclusão',
+	periodBeforeDeletionDesc: 'Excluir artigos após este período desde a criação',
+	timeUnit: 'Unidade de tempo',
+	timeUnitDesc: 'Unidade para o período de exclusão',
+	deletionCriteria: 'Critério de exclusão',
+	deletionCriteriaDesc: 'Critério para excluir artigos',
+	addNewFeed: 'Adicionar novo feed',
+	addNewFeedDesc: 'Adicionar um novo feed RSS para baixar',
+	updateFeedsNow: 'Atualizar feeds agora',
+	updateFeedsNowDesc: 'Atualizar manualmente todos os feeds RSS habilitados',
+
+	// Modal
+	feedName: 'Nome do feed',
+	feedUrl: 'URL do feed',
+	customFolderName: 'Nome de pasta personalizado (opcional)',
+	customFolderNameDesc: 'Subpasta dentro da pasta RSS',
+	customFolderPlaceholder: 'Deixe vazio para usar o nome do feed',
+
+	// Buttons
+	addFeed: 'Adicionar feed',
+	editFeed: 'Editar feed',
+	deleteFeed: 'Excluir feed',
+	save: 'Salvar',
+	cancel: 'Cancelar',
+	updateNow: 'Atualizar agora',
+	savedFeed: 'Feed salvo: %0',
+	errorSavingFeed: 'Falha ao salvar feed',
+
+	// Settings header
+	rssFeedDownloaderSettings: 'Configurações do downloader de feeds RSS',
+
+	// Time units
+	days: 'Dias',
+	minutes: 'Minutos',
+
+	// Date options
+	publishedDate: 'Data de publicação',
+	savedDate: 'Data de salvamento',
+
+	// Download history
+	downloadHistory: 'Histórico de downloads',
+	downloadHistoryDesc: 'Número de URLs de artigos baixados armazenados: %0',
+	clearDownloadHistory: 'Limpar histórico',
+	downloadHistoryCleared: 'Histórico de downloads limpo',
+
+	// Per-feed settings
+	useCustomTemplate: 'Usar template personalizado',
+	useCustomTemplateDesc: 'Substituir o template global de conteúdo para este feed. Quando desativado, a configuração global é usada.',
+	useCustomAutoDelete: 'Usar exclusão automática personalizada',
+	useCustomAutoDeleteDesc: 'Substituir as configurações globais de exclusão automática para este feed. Quando desativado, a configuração global é usada.',
+	customSettingsIndicator: 'Possui configurações personalizadas',
+};

--- a/src/adapters/i18n/localization.ts
+++ b/src/adapters/i18n/localization.ts
@@ -2,13 +2,13 @@ import { moment } from 'obsidian';
 import en from './locales/en';
 import ja from './locales/ja';
 import fr from './locales/fr';
+import pt from './locales/pt';
 
 const localeMap: { [key: string]: Partial<typeof en> } = {
 	en,
-	ja,
-	"ja-JP": ja,
-	fr,
-	"fr-FR": fr,
+	ja, "ja-JP": ja,
+	fr, "fr-FR": fr,
+	pt, "pt-BR": pt
 };
 
 export function t(

--- a/src/services/ArticleRenderer.ts
+++ b/src/services/ArticleRenderer.ts
@@ -56,4 +56,38 @@ export class ArticleRenderer {
 		templateData.content = htmlToMarkdown(processedContent);
 		return renderTemplate(preparedTemplate, templateData);
 	}
+
+	/**
+	 * RSSアイテムをsingle-file modeのMarkdownセクションとして生成
+	 * @param rssItem RSSアイテム
+	 * @param processedContent 処理済みのHTMLコンテンツ
+	 * @returns Markdownセクション文字列（--- 区切り付き）
+	 */
+	renderSection(rssItem: RssItem, processedContent: string): string {
+		const data = this.buildTemplateData(rssItem);
+		data.content = htmlToMarkdown(processedContent);
+
+		const lines: string[] = [];
+		lines.push(`## ${data.title}`, '');
+		lines.push(`**Published:** ${data.publishedTime} · **Author:** ${data.author} · [Link](${data.link})`, '');
+
+		if (data.description) {
+			lines.push(`> ${data.description}`, '');
+		}
+
+		if (rssItem.imageUrl) {
+			lines.push(`![](${rssItem.imageUrl})`, '');
+		}
+
+		if (data.tags) {
+			lines.push(data.tags, '');
+		}
+
+		if (data.content) {
+			lines.push(data.content, '');
+		}
+
+		lines.push('---', '');
+		return lines.join('\n');
+	}
 }

--- a/src/types/Settings.ts
+++ b/src/types/Settings.ts
@@ -40,6 +40,7 @@ export interface LocalRssSettings {
 	autoDeleteTimeUnit: string;
 	autoDeleteBasedOn: string;
 	downloadHistory: DownloadHistoryEntry[];
+	singleFilePerFeed: boolean;
 }
 
 export const DEFAULT_SETTINGS: LocalRssSettings = {
@@ -57,5 +58,6 @@ export const DEFAULT_SETTINGS: LocalRssSettings = {
 	autoDeleteDays: 30,
 	autoDeleteTimeUnit: 'days',
 	autoDeleteBasedOn: 'saved',
-	downloadHistory: []
+	downloadHistory: [],
+	singleFilePerFeed: false,
 };

--- a/src/ui/LocalRssSettingTab.ts
+++ b/src/ui/LocalRssSettingTab.ts
@@ -51,6 +51,16 @@ export class LocalRssSettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl)
+			.setName(t('singleFilePerFeed'))
+			.setDesc(t('singleFilePerFeedDesc'))
+			.addToggle(toggle => toggle
+				.setValue(this.settings.singleFilePerFeed)
+				.onChange(async (value) => {
+					this.settings.singleFilePerFeed = value;
+					await this.onSaveSettings();
+				}));
+
+		new Setting(containerEl)
 			.setName(t('fileNameTemplate'))
 			.setDesc(t('fileNameTemplateDesc'))
 			.addText(text => text

--- a/src/usecases/UpdateFeeds.ts
+++ b/src/usecases/UpdateFeeds.ts
@@ -62,13 +62,10 @@ export class UpdateFeeds {
 		const parser = new xml2js.Parser({ explicitArray: false });
 		const result = await parser.parseStringPromise(xml);
 
-		const feedFolderPath = normalizePath(`${baseFolderPath}/${feed.folder || feed.name}`);
-		const feedFolder = this.vault.getAbstractFileByPath(feedFolderPath);
-		if (!feedFolder) {
-			await this.vault.createFolder(feedFolderPath);
-		}
-
 		const resolved = FeedSettingsResolver.resolve(feed, this.settings);
+
+		// アイテム収集（RSS/Atom共通）
+		const collectedItems: { rssItem: RssItem; originalItem: unknown }[] = [];
 
 		// RSS or Atom判定
 		let channel = result.rss?.channel;
@@ -88,7 +85,7 @@ export class UpdateFeeds {
 				for (const item of items) {
 					const rssItem = this.rssItemBuilder.fromAtomItem(item, atomFeed, feed);
 					await this.enrichWithImage(rssItem, item);
-					await this.saveRssItem(rssItem, feedFolderPath, resolved.template);
+					collectedItems.push({ rssItem, originalItem: item });
 				}
 			} else {
 				new Notice(t('unsupportedFeedFormat', feed.name));
@@ -99,15 +96,32 @@ export class UpdateFeeds {
 			for (const item of items) {
 				const rssItem = this.rssItemBuilder.fromRssItem(item, feed);
 				await this.enrichWithImage(rssItem, item);
-				await this.saveRssItem(rssItem, feedFolderPath, resolved.template);
+				collectedItems.push({ rssItem, originalItem: item });
 			}
 		}
 
-		// 古いファイル・履歴を削除（Atom/RSS共通）
-		if (resolved.autoDeleteEnabled) {
-			await this.deleteOldFiles(feedFolderPath, resolved);
-			this.articleHistory.purgeOlderThan(this.calcCutoffDate(resolved));
+		if (this.settings.singleFilePerFeed) {
+			// single-file mode: フィードごとに1つの.mdファイルに追記
+			const feedFilePath = normalizePath(`${baseFolderPath}/${feed.folder || feed.name}.md`);
+			await this.saveItemsToFeedFile(collectedItems.map(c => c.rssItem), feedFilePath);
+		} else {
+			// デフォルト: フィードごとにフォルダを作成し、記事ごとにファイルを作成
+			const feedFolderPath = normalizePath(`${baseFolderPath}/${feed.folder || feed.name}`);
+			const feedFolder = this.vault.getAbstractFileByPath(feedFolderPath);
+			if (!feedFolder) {
+				await this.vault.createFolder(feedFolderPath);
+			}
+
+			for (const { rssItem } of collectedItems) {
+				await this.saveRssItem(rssItem, feedFolderPath, resolved.template);
+			}
+
+			if (resolved.autoDeleteEnabled) {
+				await this.deleteOldFiles(feedFolderPath, resolved);
+				this.articleHistory.purgeOlderThan(this.calcCutoffDate(resolved));
+			}
 		}
+
 		this.articleHistory.enforceCapLimit();
 	}
 
@@ -185,6 +199,44 @@ export class UpdateFeeds {
 			}
 		} catch (error) {
 			console.error('Error deleting old files:', error);
+		}
+	}
+
+	/**
+	 * 複数のRSSアイテムを1つのMarkdownファイルに保存（single-file mode）
+	 * 新しい記事はファイルの先頭に追記される
+	 */
+	private async saveItemsToFeedFile(items: RssItem[], feedFilePath: string): Promise<void> {
+		const newSections: string[] = [];
+
+		for (const rssItem of items) {
+			if (rssItem.link && this.articleHistory.hasBeenDownloaded(rssItem.link)) {
+				continue;
+			}
+
+			let processedContent = rssItem.content;
+			if (this.settings.imageWidth && this.settings.imageWidth !== '100%') {
+				processedContent = this.resizeImagesInContent(processedContent);
+			}
+
+			const section = this.articleRenderer.renderSection(rssItem, processedContent);
+			newSections.push(section);
+
+			if (rssItem.link) {
+				this.articleHistory.addToHistory(rssItem.link);
+			}
+		}
+
+		if (newSections.length === 0) return;
+
+		const newContent = newSections.join('\n');
+		const existingFile = this.vault.getAbstractFileByPath(feedFilePath);
+
+		if (existingFile instanceof TFile) {
+			const existingContent = await this.vault.read(existingFile);
+			await this.vault.modify(existingFile, newContent + '\n' + existingContent);
+		} else {
+			await this.vault.create(feedFilePath, newContent);
 		}
 	}
 


### PR DESCRIPTION
### Summary
Introduces a new optional storage mode where all articles from a feed are consolidated into a single Markdown file, instead of generating one file per article. This reduces vault clutter for users who prefer a journal-style reading experience over individual note management.

The feature is **opt-in** — the default behavior (one file per article) is fully preserved.


#### Behavior in single-file mode

- The output file is named `{feed.folder || feed.name}.md` and saved directly in the base RSS folder (no subfolder)
- Each article is prepended as a new section on every update run, keeping the most recent content at the top
- Duplicate detection still relies on `ArticleHistoryService`, so already-downloaded articles are never re-added
- Image resizing (`imageWidth` setting) is applied per section, consistent with the existing per-file behavior


> [!NOTE]
> I've added the VSCode workspace that's being used, and extensions that detect semantic errors. If you don't find them useful, you can delete them.
---

### Changes

#### `src/types/Settings.ts`
- Added `singleFilePerFeed: boolean` field to the `LocalRssSettings` interface
- Default value set to `false` in `DEFAULT_SETTINGS`, ensuring no behavioral change for existing users

#### `src/services/ArticleRenderer.ts`
- Added `renderSection(rssItem, processedContent)` method that renders an article as a Markdown section instead of a standalone file
- Section format: `## Title` heading, metadata line (published date, author, link), optional blockquote description, optional image, hashtag categories, and full content body, closed with a `---` divider

#### `src/usecases/UpdateFeeds.ts`
- Refactored `updateFeed()` to collect all feed items first, then branch on `singleFilePerFeed`
- When `false`: existing behavior — creates a subfolder per feed and one `.md` file per article
- When `true`: skips folder creation and routes to the new `saveItemsToFeedFile()` method
- Added `saveItemsToFeedFile(items, feedFilePath)`: deduplication via `ArticleHistoryService`, image resizing, section rendering, and **prepend strategy** (newest articles always appear at the top of the file)
- Auto-delete is intentionally skipped in single-file mode, as removing individual sections from a combined file is not supported

#### `src/adapters/i18n/locales/en.ts`
- Added `singleFilePerFeed` and `singleFilePerFeedDesc` localization keys

#### `src/adapters/i18n/locales/pt.ts` *(new file)*
- Added full Portuguese (pt-BR) locale covering all existing and new keys

#### `src/ui/LocalRssSettingTab.ts`
- Added a toggle for `singleFilePerFeed` in the settings tab, placed directly below the RSS folder path field

